### PR TITLE
fix(build): use HTTPS for submodules to avoid SSH errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "third-parties/claude-code-templates"]
 	path = third-parties/claude-code-templates
-	url = git@github.com:MarkShawn2020/claude-code-templates.git
+	url = https://github.com/MarkShawn2020/claude-code-templates.git
 [submodule "third-parties/claude-plugins-official"]
 	path = third-parties/claude-plugins-official
-	url = git@github.com:anthropics/claude-plugins-official.git
+	url = https://github.com/anthropics/claude-plugins-official.git
 [submodule "third-parties/claude-code-docs"]
 	path = third-parties/claude-code-docs
-	url = git@github.com:MarkShawn2020/claude-code-docs.git
+	url = https://github.com/MarkShawn2020/claude-code-docs.git
 [submodule "third-parties/codex"]
 	path = third-parties/codex
-	url = git@github.com:openai/codex.git
+	url = https://github.com/openai/codex.git


### PR DESCRIPTION
# fix(build): use HTTPS for submodules to avoid SSH errors

## Description

This PR switches the git submodule URLs in `.gitmodules` from SSH (`git@github.com:...`) to HTTPS (`https://github.com/...`).

**Reason:**
Currently, the project uses SSH URLs for submodules. This causes "resource path doesn't exist" build errors for users who do not have SSH keys configured for GitHub, or when building in environments that prefer HTTPS (like some CI/CD pipelines).

Switching to HTTPS ensures that:

1.  Submodules (`claude-code-templates`, `codex`, etc.) can be initialized and cloned reliably by anyone.
2.  `tauri dev` and `tauri build` commands succeed without missing resource errors.

## Type of Change

- [x] Bug fix (fixes build initialization issues)
- [ ] Documentation update

## Verification

- Verified that `git submodule update --init --recursive` works successfully without SSH keys.
- Confirmed that `pnpm tauri dev` builds correctly after this change.
