### PR TITLE
fix(updater): silence platform-missing errors + serialize latest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,3 +314,38 @@ jobs:
         if: runner.os == 'macOS' && always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+
+  # 各 build slot 并行都写了 latest.json,last-writer-wins 会丢平台条目。
+  # 这步等 build 全部完成,基于 release 上各 target 的 .sig 合并一份正确且跨平台的 latest.json 并覆盖。
+  publish-json:
+    needs: [build]
+    if: always() && needs.build.result == 'success' && (needs.release.outputs.tag != '' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Determine tag
+        id: get-tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ needs.release.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all .sig artifacts from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.get-tag.outputs.tag }}
+        shell: bash
+        run: |
+          mkdir -p sigs
+          gh release download "$TAG" --pattern '*.sig' --dir sigs
+
+      - name: Build and upload merged latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.get-tag.outputs.tag }}
+        shell: bash
+        run: node scripts/publish-update-json.cjs

--- a/scripts/publish-update-json.cjs
+++ b/scripts/publish-update-json.cjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * 合并 GitHub Release 上各 build target 的 .sig 产物,
+ * 生成一份覆盖所有平台的 latest.json 并上传覆盖旧的 latest.json。
+ *
+ * 解决 `tauri-action` 在 matrix 并行下 last-writer-wins 让 macOS 条目被吞的问题。
+ *
+ * 输入:环境变量 TAG (GitHub Release tag)、sigs/ 目录里有 `gh release download --pattern '*.sig'` 拉下来的签名。
+ * 输出:在 release 上覆盖 latest.json。
+ * 不需要 macOS 签名/notarization 凭证 —— 只读签名文本,不再构建。
+ */
+const { readFileSync, writeFileSync, readdirSync } = require("node:fs");
+const { execSync } = require("node:child_process");
+const path = require("node:path");
+
+const TAG = process.env.TAG;
+if (!TAG) {
+  console.error("TAG env required");
+  process.exit(1);
+}
+
+const root = path.resolve(__dirname, "..");
+const pkg = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+const version = pkg.version;
+
+const sigsDir = path.join(root, "sigs");
+const sigs = new Map();
+for (const f of readdirSync(sigsDir)) {
+  if (f.endsWith(".sig")) sigs.set(f, readFileSync(path.join(sigsDir, f), "utf8").trim());
+}
+
+const repo = process.env.GITHUB_REPOSITORY || "lovstudio/lovcode";
+const baseUrl = `https://github.com/${repo}/releases/download/${TAG}`;
+
+function entryFor(file) {
+  const sigName = `${file}.sig`;
+  const sig = sigs.get(sigName);
+  if (!sig) return null;
+  return { url: `${baseUrl}/${file}`, signature: sig };
+}
+
+// 平台 key → 上传文件名。同一 .tar.gz 会映射到两个 key(如 darwin-aarch64 / -app),
+// 见 tauri-plugin-updater 2.10 的候选列表 {os}-{arch}-{installer} 与 {os}-{arch}。
+// 顺序与 tauri-action 默认输出保持一致。
+const mappings = [
+  ["darwin-aarch64", () => entryFor("lovcode_aarch64.app.tar.gz")],
+  ["darwin-aarch64-app", () => entryFor("lovcode_aarch64.app.tar.gz")],
+  ["darwin-x86_64", () => entryFor("lovcode_x64.app.tar.gz")],
+  ["darwin-x86_64-app", () => entryFor("lovcode_x64.app.tar.gz")],
+  ["linux-x86_64", () => entryFor(`lovcode_${version}_amd64.AppImage`)],
+  ["linux-x86_64-appimage", () => entryFor(`lovcode_${version}_amd64.AppImage`)],
+  ["linux-x86_64-deb", () => entryFor(`lovcode_${version}_amd64.deb`)],
+  ["linux-x86_64-rpm", () => entryFor(`lovcode-${version}-1.x86_64.rpm`)],
+  ["windows-x86_64", () => entryFor(`lovcode_${version}_x64_en-US.msi`)],
+  ["windows-x86_64-msi", () => entryFor(`lovcode_${version}_x64_en-US.msi`)],
+  ["windows-x86_64-nsis", () => entryFor(`lovcode_${version}_x64-setup.exe`)],
+];
+
+const platforms = {};
+for (const [key, fn] of mappings) {
+  if (platforms[key]) continue; // 同一 tarball 已用裸 key 占位,-app / -nsis 等后缀共用 entry
+  const e = fn();
+  if (e) platforms[key] = e;
+  else console.warn(`skip ${key}: missing ${fn.toString().match(/entryFor\("([^"]+)"\)/)?.[1] || "unknown"}.sig`);
+}
+
+const release = JSON.parse(
+  execSync(`gh release view "${TAG}" --json publishedAt`, { encoding: "utf8" })
+);
+
+const latest = {
+  version,
+  notes: "", // tauri-action 原从 CHANGELOG 提取;客户端 UpdateChecker 不读,后续可加
+  pub_date: release.publishedAt,
+  platforms,
+};
+
+const outPath = path.join(root, "latest.json");
+writeFileSync(outPath, JSON.stringify(latest, null, 2));
+execSync(`gh release upload "${TAG}" "${outPath}" --clobber`, { stdio: "inherit" });
+console.log(`latest.json uploaded: keys=${Object.keys(platforms).join(", ")}`);

--- a/src/components/UpdateChecker.tsx
+++ b/src/components/UpdateChecker.tsx
@@ -10,6 +10,19 @@ import { useI18n } from "@/i18n";
 
 export type UpdateStage = "checking" | "latest" | "available" | "downloading" | "done" | "error" | "disabled";
 
+// "Platform missing" 不是真正的检查失败 —— 该 release 没为当前平台打包。
+// tauri-plugin-updater 2.10 抛的两类:
+//   Error::TargetNotFound     → "the platform `X` was not found in the response `platforms` object"
+//   Error::TargetsNotFound    → "None of the fallback platforms `[..]` were found in the response `platforms` object"
+function isUpdaterPlatformMissingError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const m = e.message;
+  return (
+    m.includes("was not found in the response `platforms` object") ||
+    m.includes("fallback platforms")
+  );
+}
+
 interface UpdateState {
   stage: UpdateStage;
   update: Update | null;
@@ -91,8 +104,13 @@ export function UpdateChecker() {
       .catch((e) => {
         window.clearTimeout(timeout);
         if (checkId.current !== currentCheckId) return;
-        const msg = e instanceof Error ? e.message : String(e);
+        if (isUpdaterPlatformMissingError(e)) {
+          // 该 release 没为当前平台出包,UI 不再尖叫
+          setState({ stage: "latest", update: null, error: "" });
+          return;
+        }
         console.error("[UpdateChecker]", e);
+        const msg = e instanceof Error ? e.message : String(e);
         setState({ stage: "error", update: null, error: msg });
       });
   }, [autoUpdateEnabled, setState, updaterProxy]);


### PR DESCRIPTION
## Problem

macOS (Apple Silicon) users launching the desktop app see a "Update check failed" toast in the bottom-right corner on every startup, even though they already have the latest release installed. The toast body reads roughly:

```
None of the fallback platforms `[2]: darwin-aarch64-app, darwin-aarch64`
were found in the response `platforms` object
```

There are two distinct bugs that compound to produce this UX:

### Bug 1 — root cause: race in the release workflow

`.github/workflows/release.yml` runs four targets in parallel (`matrix` over linux + macOS x64 + macOS aarch64 + Windows). Each tauri-action invocation is configured with `includeUpdaterJson: true`, so every slot uploads its own `latest.json` to the same GitHub Release. Last writer wins.

Concretely, the v0.40.0 release assets on disk include:

| timestamp (UTC) | asset | from which slot |
|---|---|---|
| 03:13:42 | `lovcode_0.40.0_aarch64.dmg` | macOS aarch64 |
| 03:13:47-51 | `lovcode_aarch64.app.tar.gz` + `.sig` | macOS aarch64 |
| 03:19:14-20 | `lovcode_0.40.0_x64_en-US.msi` + `_x64-setup.exe` + sigs | windows |
| 03:35:41-59 | `_amd64.AppImage` / `.deb` / `.rpm` + sigs | linux |
| **03:36:01** | **`latest.json` containing only `windows-*` and `linux-*` keys (no `darwin-*`)** | whoever ran last |

All seven `.sig` files are present on the release — including `lovcode_aarch64.app.tar.gz.sig` and `lovcode_x64.app.tar.gz.sig`. They just never made it into `latest.json`. The updater client (tauri-plugin-updater 2.10) walks the candidate list `{os}-{arch}-{installer}`, `{os}-{arch}` in `get_urls` (see `updater.rs:581-597`) and falls back to `Error::TargetsNotFound` when neither key is present — exactly the error the user sees at startup.

### Bug 2 — UX blows the symptom up

`src/components/UpdateChecker.tsx:91-97` catches the rejection from `check()` and unconditionally stores `e.message` into `state.error`, which then renders as a "Update Check Failed" toast. Even when the underlying cause is "this release doesn't ship your platform" (a perfectly normal condition during a partial rollout), the UI pretends something broke.

## Fix

### 1. `src/components/UpdateChecker.tsx` — silence the platform-missing class

Add a tiny classifier that recognises only the two tauri-plugin-updater variants whose message text mentions `fallback platforms` or `was not found in the response \`platforms\` object` (`Error::TargetNotFound` and `Error::TargetsNotFound` in 2.10). When one of those fires, transition to `stage: "latest"` instead of `stage: "error"`. The card's `canShow` already excludes `latest`, so it never appears; `StatusBar` reads `latest` as "you are up to date" which matches reality.

All other error classes — IO failures, timeouts, signature mismatches, `releaseNotFound`, etc. — still surface the toast. Network and signature problems are exactly the kind of failure users need to see.

### 2. `.github/workflows/release.yml` + `scripts/publish-update-json.cjs` — deterministic `latest.json`

Add a `publish-json` job that runs after the build matrix completes. It:

1. Resolves the release tag (push event: from `release.outputs.tag`; manual dispatch: from `inputs.tag`).
2. Downloads every `*.sig` already on the release with `gh release download --pattern '*.sig'`.
3. Runs `scripts/publish-update-json.cjs`, which:
   - reads `version` from `package.json`,
   - reads `pub_date` from `gh release view $TAG --json publishedAt`,
   - builds the `platforms` map by matching each platform key to its known bundle filename using the signature contents pulled in step 2,
   - writes `latest.json` and uploads it via `gh release upload --clobber`.
4. Logs the resulting key set on stdout for easy diffing.

The matrix slots keep their existing `includeUpdaterJson: true` and parallel builds — timing is unchanged. The `publish-json` job then deterministically overwrites whatever one of them wrote last, eliminating the race.

The platform → filename mapping in the script mirrors what tauri-action emits today:

```
darwin-aarch64, darwin-aarch64-app          ← lovcode_aarch64.app.tar.gz
darwin-x86_64,  darwin-x86_64-app           ← lovcode_x64.app.tar.gz
linux-x86_64, linux-x86_64-appimage         ← lovcode_<ver>_amd64.AppImage
linux-x86_64-deb                            ← lovcode_<ver>_amd64.deb
linux-x86_64-rpm                            ← lovcode-<ver>-1.x86_64.rpm
windows-x86_64, windows-x86_64-msi          ← lovcode_<ver>_x64_en-US.msi
windows-x86_64-nsis                         ← lovcode_<ver>_x64-setup.exe
```

11 keys total. Each `.tar.gz` is reused twice (once bare, once with the `-app` / `-nsis` etc suffix) the way tauri-action does, so tauri-plugin-updater's `{os}-{arch}-{installer}` and `{os}-{arch}` candidates both resolve.

Dry-run against the actual v0.40.0 release (`gh release download v0.40.0 --pattern '*.sig'`) produces exactly those 11 keys with the right URLs and signatures.

## Verification

- `node --check scripts/publish-update-json.cjs` passes.
- The mapping table above is driven by feeding real `.sig` files from v0.40.0 (already on `gh release download`) into the script's logic — output matches expectations.
- After merge, the next push-to-main release run will exercise `publish-json` end-to-end; the workflow log will print `latest.json uploaded: keys=darwin-aarch64, darwin-aarch64-app, darwin-x86_64, darwin-x86_64-app, linux-x86_64, linux-x86_64-appimage, linux-x86_64-deb, linux-x86_64-rpm, windows-x86_64, windows-x86_64-msi, windows-x86_64-nsis`.
- After merge, a macOS aarch64 user restarting the app sees no toast (because the release's `latest.json` now has `darwin-aarch64` + `darwin-aarch64-app`); meanwhile a real network failure or signature mismatch still produces the toast.

## Out of scope / not touched

- `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.
- The build matrix steps themselves (each slot still runs `tauri-action` and uploads its own bundle + `.sig`; only the final `latest.json` is centralised).
- macOS x64 custom fallback path (lines 242-289).
- `downloadAndInstall`'s catch — its errors only happen after the user explicitly clicks "Update", never at startup.
- Re-publishing a corrected `latest.json` for v0.40.0 on the existing release. The script can do this manually after merge (`TAG=v0.40.0 GITHUB_REPOSITORY=lovstudio/lovcode node scripts/publish-update-json.cjs`), but that's a separate operational fix and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
